### PR TITLE
Optimize network performance

### DIFF
--- a/traffic_pod_autoscaler/src/Proxy.py
+++ b/traffic_pod_autoscaler/src/Proxy.py
@@ -9,6 +9,7 @@ from libs.LoggerToolbox import _logger
 from libs.Toolbox import _toolbox
 from Scaler import Scaler
 
+BUFF_SIZE = 16 * 2**10 # 16KB, should be power of 2
 
 class Proxy(object):
     local_address: string
@@ -134,7 +135,7 @@ class Proxy(object):
                         _logger.exception(
                             f"Exception:Proxy_tcp_server_received_from:{e}")
 
-                    if not isinstance(data, bytes):
+                    if not isinstance(data, (bytes, bytearray)):
                         data = bytes(data, 'utf-8')
 
                     try:
@@ -219,8 +220,7 @@ class Proxy(object):
     def received_from(self, sock: socket.socket, _reconnect=False):
         _logger.debug("START")
 
-        BUFF_SIZE = 4096
-        _data = b""
+        _data = bytearray(b"")
 
         sock.setblocking(False)
         # sock.settimeout(int(self._remote_timeout))

--- a/traffic_pod_autoscaler/src/libs/LoggerToolbox.py
+++ b/traffic_pod_autoscaler/src/libs/LoggerToolbox.py
@@ -76,12 +76,14 @@ class LoggerToolbox(object):
         self._log(_message, "WARNING")
 
     def debug(self, _message):
-        _inspect_obj = inspect.stack()[1]
-        _parent_function = _inspect_obj.function
-        _parent_filename = _inspect_obj.filename
-        _parent_file_lineno = _inspect_obj.lineno
-        self._log(
-            f"[{_parent_filename}::{_parent_function}::{_parent_file_lineno}] {_message}", "DEBUG")
+        if self.level_code_DEBUG >= self._level_code:
+            _inspect_obj = inspect.stack()[1]
+            _parent_function = _inspect_obj.function
+            _parent_filename = _inspect_obj.filename
+            _parent_file_lineno = _inspect_obj.lineno
+            self._log(
+                f"[{_parent_filename}::{_parent_function}::{_parent_file_lineno}] {_message}", "DEBUG")
+
 
     def trace(self, _message):
         self._log(_message, "TRACE")


### PR DESCRIPTION
I was investigating the tpa ressources allocation in our staging cluster and I saw that:

![image](https://github.com/user-attachments/assets/0dc171a2-3d57-4d67-a88e-837ec84004ba)

I asked my self, how an auto scaler need a full cpu, I discover that the autoscaler proxy the traffic as indicated in the Readme. So I investigate the proxy performance.

I fixed some low hanging fruit, for a lot of profit :-)

With a small file (under 1Kb)

<details><summary>Before</summary>

```
➜ k6 run -u 25 -d 15s test.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: test.js
        output: -

     scenarios: (100.00%) 1 scenario, 25 max VUs, 45s max duration (incl. graceful stop):
              * default: 25 looping VUs for 15s (gracefulStop: 30s)


     data_received..................: 1.3 MB 88 kB/s
     data_sent......................: 3.3 MB 220 kB/s
     http_req_blocked...............: avg=361.04µs min=0s     med=0s      max=235.61ms p(90)=1µs     p(95)=1µs    
     http_req_connecting............: avg=360.09µs min=0s     med=0s      max=235.25ms p(90)=0s      p(95)=0s     
     http_req_duration..............: avg=25.29ms  min=8.56ms med=23.23ms max=256.66ms p(90)=24.93ms p(95)=45.81ms
       { expected_response:true }...: avg=25.29ms  min=8.56ms med=23.23ms max=256.66ms p(90)=24.93ms p(95)=45.81ms
     http_req_failed................: 0.00%  ✓ 0         ✗ 14595
     http_req_receiving.............: avg=9.74µs   min=3µs    med=6µs     max=34.62ms  p(90)=9µs     p(95)=12µs   
     http_req_sending...............: avg=3.78µs   min=1µs    med=2µs     max=9.11ms   p(90)=4µs     p(95)=5µs    
     http_req_tls_handshaking.......: avg=0s       min=0s     med=0s      max=0s       p(90)=0s      p(95)=0s     
     http_req_waiting...............: avg=25.28ms  min=8.54ms med=23.23ms max=256.38ms p(90)=24.92ms p(95)=45.81ms
     http_reqs......................: 14595  971.85852/s
     iteration_duration.............: avg=25.68ms  min=8.6ms  med=23.25ms max=444ms    p(90)=24.96ms p(95)=45.85ms
     iterations.....................: 14595  971.85852/s
     vus............................: 25     min=25      max=25 
     vus_max........................: 25     min=25      max=25 


running (15.0s), 00/25 VUs, 14595 complete and 0 interrupted iterations
default ✓ [======================================] 25 VUs  15s
```

</details> 

<details><summary>After</summary>

```
➜ k6 run -u 25 -d 15s test.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: test.js
        output: -

     scenarios: (100.00%) 1 scenario, 25 max VUs, 45s max duration (incl. graceful stop):
              * default: 25 looping VUs for 15s (gracefulStop: 30s)


     data_received..................: 30 MB  2.0 MB/s
     data_sent......................: 75 MB  5.0 MB/s
     http_req_blocked...............: avg=16.23µs min=0s      med=0s    max=233.26ms p(90)=1µs    p(95)=1µs   
     http_req_connecting............: avg=15.51µs min=0s      med=0s    max=232.84ms p(90)=0s     p(95)=0s    
     http_req_duration..............: avg=1.08ms  min=62µs    med=986µs max=99.87ms  p(90)=1.84ms p(95)=2.26ms
       { expected_response:true }...: avg=1.08ms  min=62µs    med=986µs max=99.87ms  p(90)=1.84ms p(95)=2.26ms
     http_req_failed................: 0.00%  ✓ 0            ✗ 332565
     http_req_receiving.............: avg=7.04µs  min=2µs     med=4µs   max=21.59ms  p(90)=7µs    p(95)=11µs  
     http_req_sending...............: avg=3.9µs   min=1µs     med=2µs   max=9.93ms   p(90)=4µs    p(95)=7µs   
     http_req_tls_handshaking.......: avg=0s      min=0s      med=0s    max=0s       p(90)=0s     p(95)=0s    
     http_req_waiting...............: avg=1.07ms  min=58µs    med=977µs max=99.47ms  p(90)=1.83ms p(95)=2.25ms
     http_reqs......................: 332565 22168.440284/s
     iteration_duration.............: avg=1.12ms  min=72.29µs med=1ms   max=255.39ms p(90)=1.87ms p(95)=2.29ms
     iterations.....................: 332565 22168.440284/s
     vus............................: 25     min=25         max=25  
     vus_max........................: 25     min=25         max=25  


running (15.0s), 00/25 VUs, 332565 complete and 0 interrupted iterations
default ✓ [======================================] 25 VUs  15s
```

</details>

For file larger that 200kb

<details><summary>Before</summary>

```
➜ k6 run -u 5 -d 15s test.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: test.js
        output: -

     scenarios: (100.00%) 1 scenario, 5 max VUs, 45s max duration (incl. graceful stop):
              * default: 5 looping VUs for 15s (gracefulStop: 30s)


     data_received..................: 271 MB 15 MB/s
     data_sent......................: 4.9 kB 277 B/s
     http_req_blocked...............: avg=11.72ms min=2µs      med=3µs    max=82.84ms p(90)=78.05ms p(95)=82.32ms
     http_req_connecting............: avg=11.67ms min=0s       med=0s     max=82.59ms p(90)=77.7ms  p(95)=82.2ms 
     http_req_duration..............: avg=2.41s   min=569.57ms med=2.06s  max=4.11s   p(90)=3.93s   p(95)=4.08s  
       { expected_response:true }...: avg=2.41s   min=569.57ms med=2.06s  max=4.11s   p(90)=3.93s   p(95)=4.08s  
     http_req_failed................: 0.00%  ✓ 0        ✗ 34 
     http_req_receiving.............: avg=2.98ms  min=1.9ms    med=2.86ms max=5.97ms  p(90)=3.53ms  p(95)=3.89ms 
     http_req_sending...............: avg=47.88µs min=12µs     med=15µs   max=831µs   p(90)=46.8µs  p(95)=98.59µs
     http_req_tls_handshaking.......: avg=0s      min=0s       med=0s     max=0s      p(90)=0s      p(95)=0s     
     http_req_waiting...............: avg=2.41s   min=562.77ms med=2.05s  max=4.11s   p(90)=3.93s   p(95)=4.08s  
     http_reqs......................: 34     1.935173/s
     iteration_duration.............: avg=2.43s   min=641.09ms med=2.06s  max=4.11s   p(90)=3.96s   p(95)=4.08s  
     iterations.....................: 34     1.935173/s
     vus............................: 2      min=2      max=5
     vus_max........................: 5      min=5      max=5


running (17.6s), 0/5 VUs, 34 complete and 0 interrupted iterations
default ✓ [======================================] 5 VUs  15s
```

</details>

<details><summary>After</summary>

```
➜ k6 run -u 5 -d 15s test.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: test.js
        output: -

     scenarios: (100.00%) 1 scenario, 5 max VUs, 45s max duration (incl. graceful stop):
              * default: 5 looping VUs for 15s (gracefulStop: 30s)


     data_received..................: 31 GB  2.0 GB/s
     data_sent......................: 549 kB 37 kB/s
     http_req_blocked...............: avg=126.04µs min=1µs    med=3µs     max=93.67ms  p(90)=5µs     p(95)=7µs    
     http_req_connecting............: avg=120.48µs min=0s     med=0s      max=92.53ms  p(90)=0s      p(95)=0s     
     http_req_duration..............: avg=19.28ms  min=5.09ms med=18.27ms max=158.91ms p(90)=27ms    p(95)=29.24ms
       { expected_response:true }...: avg=19.28ms  min=5.09ms med=18.27ms max=158.91ms p(90)=27ms    p(95)=29.24ms
     http_req_failed................: 0.00%  ✓ 0          ✗ 3839
     http_req_receiving.............: avg=3.04ms   min=1.05ms med=2.62ms  max=30.91ms  p(90)=3.98ms  p(95)=5.16ms 
     http_req_sending...............: avg=23.56µs  min=8µs    med=15µs    max=1.3ms    p(90)=35.2µs  p(95)=72.09µs
     http_req_tls_handshaking.......: avg=0s       min=0s     med=0s      max=0s       p(90)=0s      p(95)=0s     
     http_req_waiting...............: avg=16.21ms  min=425µs  med=15.26ms max=153.38ms p(90)=23.97ms p(95)=25.96ms
     http_reqs......................: 3839   255.666247/s
     iteration_duration.............: avg=19.52ms  min=5.17ms med=18.39ms max=164.44ms p(90)=27.13ms p(95)=29.36ms
     iterations.....................: 3839   255.666247/s
     vus............................: 5      min=5        max=5 
     vus_max........................: 5      min=5        max=5 


running (15.0s), 0/5 VUs, 3839 complete and 0 interrupted iterations
```

</details>

I changed mainly two things: 

1. On every call to `_logger.debug` an stack_trace inspection is done, whatever we log it or not. I simply disable the stack trace inspection if not needed.
2. I increase the recv buffer size from 4kb to 16kb and use an bytearray instead of an bytes buffer: bytes buffer are not mutable and every append need to reallocate a new buffer.   
